### PR TITLE
Improve ergonomics of name_of!(type …) in Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,15 @@ repository = "https://github.com/SilentByte/nameof.git"
 homepage = "https://github.com/SilentByte/nameof"
 readme = "README.md"
 
+[[test]]
+name = "nameof_type_2015_edition"
+path = "tests/nameof_type_2015_edition.rs"
+edition = "2015"
+
+[[test]]
+name = "nameof_type_2018_edition"
+path = "tests/nameof_type_2018_edition.rs"
+edition = "2018"
+
 [badges]
 travis-ci = { repository = "SilentByte/nameof", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ macro_rules! name_of {
 
     // Covers Types
     (type $t: ty) => {{
-        name_of_type!($t)
+        $crate::name_of_type!($t)
     }};
 
     // Covers Struct Fields

--- a/tests/nameof_type_2015_edition.rs
+++ b/tests/nameof_type_2015_edition.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nameof;
+
+struct File {}
+
+#[test]
+fn nameof_type_works() {
+    assert_eq!("File", name_of!(type File));
+}

--- a/tests/nameof_type_2018_edition.rs
+++ b/tests/nameof_type_2018_edition.rs
@@ -1,0 +1,8 @@
+use nameof::name_of;
+
+struct File {}
+
+#[test]
+fn nameof_type_works() {
+    assert_eq!("File", name_of!(type File));
+}


### PR DESCRIPTION
This PR improves the ergonomics of using `name_of!(type …)` in the 2018 edition.

By adding the `$crate::` prefix to the invocation of the `name_of_type!`, users of the `name_of!` macro  don't have to import `name_of_type!` macro too.