### PR TITLE
Use 'unused borrow that must be used'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ macro_rules! name_of {
     // Covers Bindings
     ($n: ident) => {{
         let _ = || {
-            &$n;
+            let _ = &$n;
         };
         stringify!($n)
     }};


### PR DESCRIPTION
Silence one of warn-by-default lints: borrow at `&$n` triggers the linter warning. So let's "use" that `&` for a binding.